### PR TITLE
update voucher envelope obfuscation table

### DIFF
--- a/DeDRM_plugin/ion.py
+++ b/DeDRM_plugin/ion.py
@@ -735,11 +735,11 @@ SYM_NAMES = [ 'com.amazon.drm.Envelope@1.0',
               'com.amazon.drm.EncryptedPage@2.0',
               'com.amazon.drm.PlainText@2.0', 'compression_algorithm',
               'com.amazon.drm.Compressed@1.0', 'page_index_table',
-              'com.amazon.drm.VoucherEnvelope@2.0', 'com.amazon.drm.VoucherEnvelope@3.0' ]
               ] + ['com.amazon.drm.VoucherEnvelope@%d.0' % n
                    for n in list(range(2, 29)) + [
                                    9708, 1031, 2069, 9041, 3646,
                                    6052, 9479, 9888, 4648, 5683]]
+
 def addprottable(ion):
     ion.addtocatalog("ProtectedData", 1, SYM_NAMES)
 

--- a/DeDRM_plugin/ion.py
+++ b/DeDRM_plugin/ion.py
@@ -512,6 +512,8 @@ class BinaryIonParser(object):
 
         if table is not None:
             self.symbols.import_(table, min(maxid, len(table.symnames)))
+            if len(table.symnames) < maxid:
+                self.symbols.importunknown(name + "-unknown", maxid - len(table.symnames))
         else:
             self.symbols.importunknown(name, maxid)
 


### PR DESCRIPTION
from llrosy798:

> I found latest secret obfuscation table from Kindle.
> Unfortunately, currently I verified with Kindle for PC 1.30.0 (59056) and voucher-envelope@4.0 only.